### PR TITLE
add basic travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: trusty
+language: node_js
+node_js:
+- "10.10.0"
+cache:
+  directories:
+  - node_modules
+install: yarn
+script:
+- yarn build
+notifications:
+  email: true


### PR DESCRIPTION
This adds a very basic travis integration as mentioned in https://github.com/Coding-Coach/coding-coach-api/issues/7. However, running the tests currently doesn't allow the build to run successfully (as mentioned on slack), have a look at my fork's build on travis: https://travis-ci.org/frederikprijck/coding-coach-api/builds/445832567